### PR TITLE
if context value is undefined don't use it

### DIFF
--- a/api/src/lib/validator/constraints/row-not-exists-except.js
+++ b/api/src/lib/validator/constraints/row-not-exists-except.js
@@ -11,7 +11,10 @@ module.exports = (bookshelf, ValidationError) => {
 
         var query = Model.where(where);
 
-        query.where(exceptColumn, '!=', get(options.context, contextValuePath));
+        const contextValue = get(options.context, contextValuePath);
+        if (contextValue) {
+          query.where(exceptColumn, '!=', contextValue);
+        }
 
         query.fetch()
           .then(model => {

--- a/api/src/lib/validator/constraints/row-not-exists-except.js
+++ b/api/src/lib/validator/constraints/row-not-exists-except.js
@@ -12,7 +12,7 @@ module.exports = (bookshelf, ValidationError) => {
         var query = Model.where(where);
 
         const contextValue = get(options.context, contextValuePath);
-        if (contextValue) {
+        if (typeof contextValue === 'undefined') {
           query.where(exceptColumn, '!=', contextValue);
         }
 


### PR DESCRIPTION
This makes rowNotExistsExcept behave like rowNotExists in the case
where the key value is not provided. So, if you use a single route
for both edit/add we don't error out because add doesn't provide
the id.